### PR TITLE
Support json output from Terraform 0.12.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,18 @@ output "task_definition_arn" {
 }
 ```
 
+Terraform 0.12 and later intentionally track only root module outputs in the state. To expose module outputs for external consumption, you must export them from the root module using an output block, which as of 0.12 can now be done for a single module all in one output:
+
+```hcl
+output "custom_ecs_task" {
+  value = module.custom_ecs_task
+}
+```
+
 Once you have applied your terraform config, pull the output into a json:
 
 ```bash
-$ terraform output -module=custom_ecs_task -json > output.json
+$ terraform output -json custom_ecs_task > output.json
 ```
 
 Now you can use `terraecs` to run any command based off the above task-definition:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='terraecs',
-    version='0.0.3',
+    version='1.0.0',
     author='Gunter Grodotzki',
     author_email='gunter@grodotzki.co.za',
     description='A simple Fargate after Terraform runner.',

--- a/terraecs/__main__.py
+++ b/terraecs/__main__.py
@@ -33,7 +33,7 @@ def run(command):
         exit(1)
 
     for required_key in ['cluster_id', 'task_definition_arn', 'subnets', 'security_group_id']:
-        if not required_key in terraform_output or len(terraform_output[required_key]['value']) == 0:
+        if not required_key in terraform_output or len(terraform_output[required_key]) == 0:
             logging.error(f'could not find the {required_key}... Aborting')
             exit(1)
 
@@ -42,15 +42,15 @@ def run(command):
     logs_client = boto3.client('logs')
 
     task_definition = ecs_client.describe_task_definition(
-        taskDefinition=terraform_output['task_definition_arn']['value']
+        taskDefinition=terraform_output['task_definition_arn']
     )
 
     log_options = task_definition['taskDefinition']['containerDefinitions'][0]['logConfiguration']['options']
 
     # create new task with command override
     response = ecs_client.run_task(
-        cluster=terraform_output['cluster_id']['value'],
-        taskDefinition=terraform_output['task_definition_arn']['value'],
+        cluster=terraform_output['cluster_id'],
+        taskDefinition=terraform_output['task_definition_arn'],
         overrides={
             'containerOverrides': [
                 {
@@ -64,8 +64,8 @@ def run(command):
         launchType='FARGATE',
         networkConfiguration={
             'awsvpcConfiguration': {
-                'subnets': terraform_output['subnets']['value'],
-                'securityGroups': [terraform_output['security_group_id']['value']],
+                'subnets': terraform_output['subnets'],
+                'securityGroups': [terraform_output['security_group_id']],
                 'assignPublicIp': 'DISABLED',
             }
         },
@@ -82,7 +82,7 @@ def run(command):
     last_status = None
     while True:
         response = ecs_client.describe_tasks(
-            cluster=terraform_output['cluster_id']['value'],
+            cluster=terraform_output['cluster_id'],
             tasks=[task_arn],
         )
 


### PR DESCRIPTION
Terraform 0.12.x does not include the 'value' key in it's json output, remove it accordingly.