### PR TITLE
Handle missing exitCode

### DIFF
--- a/terraecs/__main__.py
+++ b/terraecs/__main__.py
@@ -11,7 +11,11 @@ output_file = None
 def get_exit_code(containers):
     for container in containers:
         if  '-cli' in container['name']:
-            return container['exitCode']
+            exit_code = container.get('exitCode')
+            if exit_code is None:
+                logging.error(f'could not find exit code for {container["name"]}', extra={'container': container})
+                exit_code = 1
+            return exit_code
 
 @click.group()
 @click.option('-f', type=click.File('rb'))


### PR DESCRIPTION
Reports of ECS containers not reporting an exitCode for some reason.
This handles that case, logs what's in the container variable and exits with 1.

```
[2024-01-06T05:34:18.693Z]   File "/usr/local/bin/terraecs", line 155, in run
[2024-01-06T05:34:18.693Z]     exit(get_exit_code(response["tasks"][0]["containers"]))
[2024-01-06T05:34:18.693Z]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2024-01-06T05:34:18.693Z]   File "/usr/local/bin/terraecs", line 17, in get_exit_code
[2024-01-06T05:34:18.693Z]     return container["exitCode"]
[2024-01-06T05:34:18.693Z]            ~~~~~~~~~^^^^^^^^^^^^
[2024-01-06T05:34:18.693Z] KeyError: 'exitCode'
```