### PR TITLE
Add slack notification for start/finish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Optional channel, default to whatever is setup on webhook
+# SLACK_CHANNEL=
+# Optional webhook URL. If no webhook is provided, the command will not send any messages.
+# SLACK_WEBHOOK_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-/.vscode/
+/*.egg-info
+/.env
 /.venv/
-
 /build/
 /dist/
-/*.egg-info
-__pycache__
-
 /output.json
+__pycache__

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ _Preview release, please do not use for anything important!_
 
 ```bash
 $ pip install terraecs
+$ cp .env.example .env
 ```
+Edit the `.env` file to your taste for Slack notifications.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setuptools.setup(
     install_requires=[
       'boto3',
       'click',
+      'python-dotenv',
+      'requests',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Add slack notifications for start/finish.

Two environment variables control this:
* SLACK_WEBHOOK_URL - if defined, notifications will be sent.
* SLACK_CHANNEL - if defined, notification will be sent to this channel, otherwise the default defined on the webhook.

Added `python-dotenv` package to load a `.env` file. In your current working directory, or I think alongside the binary file should work.